### PR TITLE
Add admin users to "Users" group so entity generator works

### DIFF
--- a/import/jhipster-users-0.json
+++ b/import/jhipster-users-0.json
@@ -29,7 +29,7 @@
       "account" : [ "view-profile", "manage-account" ]
     },
     "notBefore" : 0,
-    "groups" : [  "/Admins" ]
+    "groups" : [  "/Admins", "/Users" ]
   }, {
     "id" : "c4af4e2f-b432-4c3b-8405-cca86cd5b97b",
     "createdTimestamp" : 1505479373742,


### PR DESCRIPTION
If "admin" is in Admins, but not "Users", the entity generation works, but users are unable to navigate to entity screens when logged in as admin. This fixes that issue.